### PR TITLE
Update battery status attribute name

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -9,14 +9,14 @@ sensor:
     password: PASSWORD
     json_attributes:
       - Status
-      - BatteryStatusAfter
+      - BatteryStatus
     value_template: 'OK'
   - platform: template
     sensors:
         frontdoor_status:
             value_template: '{{ states.sensor.frontdoor_sensor.attributes["Status"] }}'
         frontdoor_battery:
-            value_template: '{{ (states.sensor.frontdoor_sensor.attributes["BatteryStatusAfter"] | int /255 * 100) | int }}'
+            value_template: '{{ (states.sensor.frontdoor_sensor.attributes["BatteryStatus"] | int /255 * 100) | int }}'
             
 switch:
   - platform: command_line


### PR DESCRIPTION
The json-response from the glue API does not (longer?) contain 'BatteryStatusAfter' but rather 'BatteryStatus'